### PR TITLE
Add automated dev setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ The memory palace will be available at:
 - Neo4j Browser: http://localhost:7474
 - API Documentation: http://localhost:8000/docs
 
+### Non-interactive setup
+
+For automated environments (e.g., Codex agents) that need a one-shot setup and launch, run:
+
+```bash
+./codex-setup.sh
+```
+
+This script installs dependencies, starts Neo4j, and launches the FastAPI app in a single step.
+
 ## Using the Memory Palace
 
 ### Storing a Memory

--- a/codex-setup.sh
+++ b/codex-setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure uv is installed
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Ensure required Python version
+uv python install 3.13 >/dev/null
+
+# Install project dependencies including dev extras
+uv sync --extra dev
+
+# Create .env from example if missing
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
+# Verify Docker availability
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required but not installed." >&2
+  exit 1
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "Docker Compose v2 is required but not available." >&2
+  exit 1
+fi
+
+# Start Neo4j container
+docker compose up -d neo4j
+
+echo "Waiting for Neo4j to be ready..."
+until docker compose exec -T neo4j cypher-shell -u neo4j -p password "RETURN 1" &>/dev/null; do
+  sleep 1
+  echo -n "."
+done
+echo ""
+
+# Start FastAPI app (with reload for dev)
+uv run uvicorn memory_palace.main:app --reload --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add `codex-setup.sh` script to install dependencies, start Neo4j, and launch FastAPI in one go
- document non-interactive setup option in README

## Testing
- `uv run ruff check .` (fails: Found 41 errors)
- `uv run pytest`
- `shellcheck codex-setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899d8aa5dfc8321af983ffdc7555de5