### PR TITLE
feat: add neo4j embedding cache

### DIFF
--- a/src/memory_palace/infrastructure/embeddings/cache.py
+++ b/src/memory_palace/infrastructure/embeddings/cache.py
@@ -1,0 +1,39 @@
+import hashlib
+
+from neo4j import AsyncSession
+
+
+class EmbeddingCache:
+    """Neo4j-backed cache for embedding vectors."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_cached(self, text: str) -> list[float] | None:
+        """Retrieve a cached embedding if available and not expired."""
+        text_hash = hashlib.md5(text.encode()).hexdigest()
+        result = await self.session.run(
+            """
+            MATCH (e:EmbeddingCache {text_hash: $hash})
+            WHERE e.created > datetime() - duration('P30D')
+            SET e.hit_count = COALESCE(e.hit_count, 0) + 1
+            RETURN e.vector AS embedding
+            """,
+            hash=text_hash,
+        )
+        record = await result.single()
+        return record["embedding"] if record else None
+
+    async def store(self, text: str, embedding: list[float]) -> None:
+        """Store an embedding in the cache."""
+        text_hash = hashlib.md5(text.encode()).hexdigest()
+        await self.session.run(
+            """
+            MERGE (e:EmbeddingCache {text_hash: $hash})
+            ON CREATE SET e.hit_count = 0
+            SET e.vector = $embedding,
+                e.created = datetime()
+            """,
+            hash=text_hash,
+            embedding=embedding,
+        )

--- a/src/memory_palace/main.py
+++ b/src/memory_palace/main.py
@@ -18,6 +18,7 @@ from memory_palace.api import dependencies
 from memory_palace.api.endpoints import admin, core, memory, unified_query
 from memory_palace.api.oauth import router as oauth_router
 from memory_palace.core.logging import get_logger, setup_logging
+from memory_palace.infrastructure.embeddings.cache import EmbeddingCache
 from memory_palace.infrastructure.embeddings.voyage import VoyageEmbeddingService
 from memory_palace.infrastructure.neo4j.driver import (
     Neo4jQuery,
@@ -60,9 +61,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG001
         await ensure_vector_index(neo4j_driver)
         logger.info("✅ Vector index initialized")
 
-        # Initialize embedding service
+        # Initialize embedding service with cache
         logger.info("🧮 Initializing Embedding Service...")
-        embedding_service = VoyageEmbeddingService()
+        embedding_cache = EmbeddingCache(neo4j_driver.session())
+        embedding_service = VoyageEmbeddingService(cache=embedding_cache)
 
         # Set global dependencies for API endpoints
         dependencies.neo4j_driver = neo4j_driver


### PR DESCRIPTION
## Summary
- add EmbeddingCache to reuse embeddings from Neo4j
- integrate cache with VoyageEmbeddingService and app startup
- expose admin endpoint for cache statistics
- initialize hit counters on new cache entries

## Testing
- `uv run ruff check --fix src/memory_palace/infrastructure/embeddings/voyage.py src/memory_palace/main.py src/memory_palace/api/endpoints/admin.py src/memory_palace/infrastructure/embeddings/cache.py`
- `uv run pytest -q`
- `uv run ty check` *(fails: Found 10 diagnostics)*

------
https://chatgpt.com/codex/tasks/task_e_6899e651064083219945e084930adbd1