### PR TITLE
feat: add clustering and background jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "python-jose[cryptography]>=3.5.0",
     "python-multipart>=0.0.20",
     "passlib>=1.7.4",
+    "scikit-learn>=1.3.0",
+    "numpy>=1.24.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/import_curated_memories.py
+++ b/scripts/import_curated_memories.py
@@ -8,7 +8,7 @@ analyzed and scored our conversations.
 import asyncio
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import timezone
 from pathlib import Path
 from uuid import UUID, uuid4
 
@@ -246,7 +246,6 @@ async def main():
             memory_service = MemoryService(
                 session=session,
                 embeddings=embedding_service,
-                clusterer=None
             )
             
             # Import the curated memories

--- a/scripts/import_friendship_memories.py
+++ b/scripts/import_friendship_memories.py
@@ -254,7 +254,6 @@ async def main():
             memory_service = MemoryService(
                 session=session,
                 embeddings=embedding_service,
-                clusterer=None  # Will auto-classify based on embeddings
             )
             
             # Use one conversation ID for all if not separating

--- a/scripts/import_tiered_memories.py
+++ b/scripts/import_tiered_memories.py
@@ -310,7 +310,6 @@ async def main():
             memory_service = MemoryService(
                 session=session,
                 embeddings=embedding_service,
-                clusterer=None
             )
             
             total_imported = 0

--- a/src/memory_palace/api/dependencies.py
+++ b/src/memory_palace/api/dependencies.py
@@ -24,7 +24,10 @@ async def get_memory_service() -> MemoryService:
     # Create a new session for this request
     # Note: The session will be cleaned up when the request completes
     session = neo4j_driver.session()
-    return MemoryService(
+    service = MemoryService(
         session=session,
         embeddings=embedding_service,
     )
+    # Initialize the service (load clustering model if needed)
+    await service.initialize()
+    return service

--- a/src/memory_palace/api/dependencies.py
+++ b/src/memory_palace/api/dependencies.py
@@ -27,5 +27,4 @@ async def get_memory_service() -> MemoryService:
     return MemoryService(
         session=session,
         embeddings=embedding_service,
-        clusterer=None
     )

--- a/src/memory_palace/services/clustering/__init__.py
+++ b/src/memory_palace/services/clustering/__init__.py
@@ -1,0 +1,5 @@
+"""Clustering service implementations."""
+
+from .dbscan_service import DBSCANClusteringService
+
+__all__ = ["DBSCANClusteringService"]

--- a/src/memory_palace/services/clustering/dbscan_service.py
+++ b/src/memory_palace/services/clustering/dbscan_service.py
@@ -1,0 +1,75 @@
+import base64
+import pickle
+
+import numpy as np
+from sklearn.cluster import DBSCAN
+
+
+class DBSCANClusteringService:
+    def __init__(self, eps: float = 0.3, min_samples: int = 3):
+        self.eps = eps
+        self.min_samples = min_samples
+        self.clusterer: DBSCAN | None = None
+        self.fitted_embeddings: np.ndarray | None = None
+
+    async def fit(self, embeddings: list[list[float]]) -> None:
+        """Fit the clustering model on all embeddings."""
+        X = np.array(embeddings)
+        self.fitted_embeddings = X
+
+        self.clusterer = DBSCAN(
+            eps=self.eps,
+            min_samples=self.min_samples,
+            metric="cosine",
+        )
+        self.clusterer.fit(X)
+
+    async def predict(self, embeddings: list[list[float]]) -> list[int]:
+        """Predict cluster labels for new embeddings."""
+        if self.clusterer is None or self.fitted_embeddings is None:
+            # If not fitted, fit on these embeddings
+            await self.fit(embeddings)
+            return self.clusterer.labels_.tolist()
+
+        # For new points, find nearest cluster
+        X = np.array(embeddings)
+        labels: list[int] = []
+
+        for embedding in X:
+            # Find nearest neighbor in fitted data
+            distances = np.dot(self.fitted_embeddings, embedding)
+            nearest_idx = np.argmax(distances)
+            nearest_label = self.clusterer.labels_[nearest_idx]
+            labels.append(int(nearest_label))
+
+        return labels
+
+    async def save_model(self, session) -> None:
+        """Persist model to Neo4j."""
+        if self.clusterer:
+            model_bytes = pickle.dumps(self.clusterer)
+            model_b64 = base64.b64encode(model_bytes).decode("utf-8")
+            await session.run(
+                """
+                MERGE (m:ClusterModel {name: 'default'})
+                SET m.data = $model,
+                    m.updated = datetime()
+                """,
+                model=model_b64,
+            )
+
+    async def load_model(self, session) -> bool:
+        """Load model from Neo4j."""
+        result = await session.run(
+            """
+            MATCH (m:ClusterModel {name: 'default'})
+            RETURN m.data as model
+            """
+        )
+        record = await result.single()
+        if record:
+            model_b64 = record["model"]
+            model_bytes = base64.b64decode(model_b64)
+            self.clusterer = pickle.loads(model_bytes)
+            return True
+        return False

--- a/src/memory_palace/services/dream_jobs.py
+++ b/src/memory_palace/services/dream_jobs.py
@@ -5,222 +5,183 @@ from typing import TYPE_CHECKING
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 if TYPE_CHECKING:
-    from memory_palace.services.memory_service import MemoryService
+    from neo4j import AsyncDriver
+
+    from memory_palace.services import ClusteringService, EmbeddingService
 
 logger = logging.getLogger(__name__)
 
 
 class DreamJobOrchestrator:
     """Background jobs for ontology maintenance and memory lifecycle management."""
-    
-    def __init__(self, memory_service: "MemoryService"):
-        self.memory = memory_service
+
+    def __init__(
+        self,
+        driver: "AsyncDriver",
+        embeddings: "EmbeddingService",
+        clusterer: "ClusteringService",
+    ):
+        self.driver = driver
+        self.embeddings = embeddings
+        self.clusterer = clusterer
         self.scheduler = AsyncIOScheduler()
         self._setup_jobs()
-    
+
+    async def _get_session(self):
+        """Helper to get a new session for each job."""
+        return self.driver.session()
+
     def _setup_jobs(self):
         """Configure the dream jobs with proper scheduling."""
-        # Every 5 minutes: salience refresh and memory eviction
         self.scheduler.add_job(
             self.refresh_salience,
-            'interval',
+            "interval",
             minutes=5,
-            id='salience_refresh',
-            max_instances=1,  # Prevent overlapping executions
-            coalesce=True
+            id="salience_refresh",
+            max_instances=1,
+            coalesce=True,
         )
-        
-        # Hourly: cluster recent memories without topic assignments
         self.scheduler.add_job(
             self.cluster_recent,
-            'interval',
+            "interval",
             hours=1,
-            id='cluster_recent',
+            id="cluster_recent",
             max_instances=1,
-            coalesce=True
+            coalesce=True,
         )
-        
-        # Nightly: full recluster at 3 AM
         self.scheduler.add_job(
             self.nightly_recluster,
-            'cron',
+            "cron",
             hour=3,
             minute=0,
-            id='nightly_recluster',
-            max_instances=1
+            id="nightly_recluster",
+            max_instances=1,
         )
-    
+
     async def start(self):
-        """Start the scheduler."""
         self.scheduler.start()
         logger.info("DreamJobOrchestrator started - background memory maintenance active")
-    
+
     async def shutdown(self):
-        """Gracefully shutdown the scheduler."""
         self.scheduler.shutdown(wait=True)
         logger.info("DreamJobOrchestrator shutdown complete")
-    
+
     async def refresh_salience(self):
         """Update salience with exponential decay and evict low-salience memories."""
         try:
-            # 45-day half-life: λ = ln(2)/45 ≈ 0.0154
-            decay_lambda = 0.0154
-            decay_factor = 1 - decay_lambda
-            
-            from memory_palace.infrastructure.neo4j.query_builder import CypherQueryBuilder
-            
-            # Apply decay to all memories with salience > eviction threshold
-            builder = CypherQueryBuilder()
-            decay_query = (
-                builder
-                .match(lambda p: p.node("Memory", "m"))
-                .where("m.salience > 0.05")
-                .set_property("m", {
-                    "salience": f"m.salience * {decay_factor}"
-                })
-                .return_clause("count(m) as updated")
-            )
-            
-            result = await self.memory.neo4j.execute_builder(decay_query)
-            updated_count = result[0]['updated'] if result else 0
-            logger.info(f"Applied salience decay to {updated_count} memories")
-            
-            # Evict memories below threshold
-            eviction_builder = CypherQueryBuilder()
-            eviction_query = (
-                eviction_builder
-                .match(lambda p: p.node("Memory", "m"))
-                .where("m.salience < 0.05")
-                .detach_delete("m")
-                .return_clause("count(m) as evicted")
-            )
-            
-            eviction_result = await self.memory.neo4j.execute_builder(eviction_query)
-            evicted_count = eviction_result[0]['evicted'] if eviction_result else 0
-            
-            if evicted_count > 0:
-                logger.info(f"Evicted {evicted_count} low-salience memories")
-                
+            async with self.driver.session() as session:
+                result = await session.run(
+                    """
+                    MATCH (m:Memory)
+                    WHERE m.salience > 0.05
+                    SET m.salience = m.salience * 0.9846
+                    RETURN count(m) as updated
+                    """,
+                )
+                record = await result.single()
+                updated = record["updated"] if record else 0
+                logger.info(f"Applied salience decay to {updated} memories")
+
+                result = await session.run(
+                    """
+                    MATCH (m:Memory)
+                    WHERE m.salience < 0.05
+                    DETACH DELETE m
+                    RETURN count(m) as evicted
+                    """,
+                )
+                record = await result.single()
+                evicted = record["evicted"] if record else 0
+                if evicted > 0:
+                    logger.info(f"Evicted {evicted} low-salience memories")
         except Exception as e:
             logger.error(f"Error during salience refresh: {e}", exc_info=True)
-    
+
     async def cluster_recent(self):
         """Assign clusters to recent unassigned memories."""
         try:
-            from memory_palace.infrastructure.neo4j.query_builder import CypherQueryBuilder
-            
-            # Get recent memories without topic_id (created in last 24 hours)
-            query_builder = CypherQueryBuilder()
-            query = (
-                query_builder
-                .match(lambda p: p.node("Memory", "m"))
-                .where("m.topic_id IS NULL")
-                .where(f"m.timestamp > {datetime.now().timestamp() - 86400}")  # Last 24 hours
-                .return_clause("m")
-                .order_by("m.timestamp DESC")
-                .limit(500)
-            )
-            
-            unassigned = await self.memory.neo4j.execute_builder(query)
-            if not unassigned:
-                logger.debug("No unassigned memories found for clustering")
-                return
-            
-            logger.info(f"Found {len(unassigned)} unassigned memories for clustering")
-            
-            # Extract embeddings
-            embeddings = [m['embedding'] for m in unassigned]
-            
-            # Predict clusters using the clusterer
-            if hasattr(self.memory, 'clusterer'):
-                topic_ids = await self.memory.clusterer.predict(embeddings)
-                
-                # Update memories with assignments
-                assigned_count = 0
-                for memory, topic_id in zip(unassigned, topic_ids, strict=False):
-                    if topic_id != -1:  # Not noise
-                        update_builder = CypherQueryBuilder()
-                        update_query = (
-                            update_builder
-                            .match(lambda p: p.node("Memory", "m"))
-                            .where(f"m.id = '{memory['id']}'")
-                            .set_property("m", {"topic_id": topic_id})
+            cutoff = datetime.now().timestamp() - 86400
+            async with self.driver.session() as session:
+                result = await session.run(
+                    """
+                    MATCH (m:Memory)
+                    WHERE m.topic_id IS NULL AND m.timestamp > $cutoff
+                    RETURN m.id AS id, m.embedding AS embedding
+                    ORDER BY m.timestamp DESC
+                    LIMIT 500
+                    """,
+                    cutoff=cutoff,
+                )
+                records = await result.to_list()
+                if not records:
+                    logger.debug("No unassigned memories found for clustering")
+                    return
+
+                embeddings = [r["embedding"] for r in records]
+                topic_ids = await self.clusterer.predict(embeddings)
+
+                assigned = 0
+                for record, topic_id in zip(records, topic_ids, strict=False):
+                    if topic_id != -1:
+                        await session.run(
+                            """MATCH (m:Memory {id: $id}) SET m.topic_id = $topic_id""",
+                            id=record["id"],
+                            topic_id=topic_id,
                         )
-                        await self.memory.neo4j.execute_builder(update_query)
-                        assigned_count += 1
-                
-                logger.info(f"Assigned topic IDs to {assigned_count} memories")
-            else:
-                logger.warning("Clusterer not available - skipping topic assignment")
-                
+                        assigned += 1
+                logger.info(f"Assigned topic IDs to {assigned} memories")
         except Exception as e:
             logger.error(f"Error during recent memory clustering: {e}", exc_info=True)
-    
+
     async def nightly_recluster(self):
         """Perform full recluster of all memories to optimize topic boundaries."""
         try:
-            logger.info("Starting nightly full recluster")
-            
-            from memory_palace.infrastructure.neo4j.query_builder import CypherQueryBuilder
-            
-            # Get all memories with embeddings
-            query_builder = CypherQueryBuilder()
-            query = (
-                query_builder
-                .match(lambda p: p.node("Memory", "m"))
-                .where("m.embedding IS NOT NULL")
-                .return_clause("m.id as id", "m.embedding as embedding", "m.topic_id as current_topic")
-                .order_by("m.timestamp DESC")
-            )
-            
-            all_memories = await self.memory.neo4j.execute_builder(query)
-            if len(all_memories) < 10:  # Need minimum memories for clustering
-                logger.info("Insufficient memories for full recluster")
-                return
-            
-            logger.info(f"Reclustering {len(all_memories)} memories")
-            
-            # Extract embeddings for full recluster
-            embeddings = [m['embedding'] for m in all_memories]
-            
-            if hasattr(self.memory, 'clusterer'):
-                # Perform full refit and predict
-                await self.memory.clusterer.fit(embeddings)
-                new_topic_ids = await self.memory.clusterer.predict(embeddings)
-                
-                # Update all memories with new topic assignments
-                updated_count = 0
-                for memory, new_topic_id in zip(all_memories, new_topic_ids, strict=False):
-                    if memory['current_topic'] != new_topic_id:
-                        update_builder = CypherQueryBuilder()
-                        update_query = (
-                            update_builder
-                            .match(lambda p: p.node("Memory", "m"))
-                            .where(f"m.id = '{memory['id']}'")
-                            .set_property("m", {"topic_id": new_topic_id})
+            async with self.driver.session() as session:
+                result = await session.run(
+                    """
+                    MATCH (m:Memory)
+                    WHERE m.embedding IS NOT NULL
+                    RETURN m.id AS id, m.embedding AS embedding, m.topic_id AS current_topic
+                    ORDER BY m.timestamp DESC
+                    """,
+                )
+                records = await result.to_list()
+                if len(records) < 10:
+                    logger.info("Insufficient memories for full recluster")
+                    return
+
+                embeddings = [r["embedding"] for r in records]
+                await self.clusterer.fit(embeddings)
+                new_topic_ids = await self.clusterer.predict(embeddings)
+
+                updated = 0
+                for record, new_id in zip(records, new_topic_ids, strict=False):
+                    if record["current_topic"] != new_id:
+                        await session.run(
+                            """MATCH (m:Memory {id: $id}) SET m.topic_id = $topic_id""",
+                            id=record["id"],
+                            topic_id=new_id,
                         )
-                        await self.memory.neo4j.execute_builder(update_query)
-                        updated_count += 1
-                
-                logger.info(f"Full recluster complete - updated {updated_count} topic assignments")
-            else:
-                logger.warning("Clusterer not available - skipping full recluster")
-                
+                        updated += 1
+                await self.clusterer.save_model(session)
+                logger.info(
+                    f"Full recluster complete - updated {updated} topic assignments"
+                )
         except Exception as e:
             logger.error(f"Error during nightly recluster: {e}", exc_info=True)
-    
+
     def get_job_status(self) -> dict:
         """Get status of all scheduled jobs."""
         jobs = self.scheduler.get_jobs()
         return {
-            'scheduler_running': self.scheduler.running,
-            'jobs': [
+            "scheduler_running": self.scheduler.running,
+            "jobs": [
                 {
-                    'id': job.id,
-                    'name': job.name,
-                    'next_run': job.next_run_time.isoformat() if job.next_run_time else None,
-                    'func': job.func.__name__
+                    "id": job.id,
+                    "name": job.name,
+                    "next_run": job.next_run_time.isoformat() if job.next_run_time else None,
+                    "func": job.func.__name__,
                 }
                 for job in jobs
-            ]
+            ],
         }

--- a/src/memory_palace/services/memory_service.py
+++ b/src/memory_palace/services/memory_service.py
@@ -47,10 +47,8 @@ class MemoryService:
     def __init__(self, session: AsyncSession, embeddings: EmbeddingService):
         self.session = session
         self.embeddings = embeddings
-        # Initialize clustering service and load model
+        # Initialize clustering service (model will be loaded separately)
         self.clusterer = DBSCANClusteringService()
-        # Store task reference to avoid garbage collection
-        self._model_task = asyncio.create_task(self.clusterer.load_model(session))
 
         # Create typed repositories
         self.friend_repo = GenericMemoryRepository[FriendUtterance](session)
@@ -58,6 +56,10 @@ class MemoryService:
         # Use the specialized MemoryRepository for the discriminated union
         self.memory_repo = MemoryRepository(session)
         self.relationship_repo = GenericMemoryRepository[MemoryRelationship](session)
+    
+    async def initialize(self) -> None:
+        """Initialize the service, loading models etc."""
+        await self.clusterer.load_model(self.session)
     
     async def run_query(self, query: str, **params):
         """Helper method to run queries with proper type casting.

--- a/src/memory_palace/services/memory_service.py
+++ b/src/memory_palace/services/memory_service.py
@@ -11,7 +11,6 @@ This module implements MP-002, MP-003, and MP-008 by providing:
 from __future__ import annotations
 
 # Standard logging replaced with Logfire logging
-import asyncio
 from typing import TYPE_CHECKING, LiteralString, cast
 from uuid import UUID, uuid4
 


### PR DESCRIPTION
## Summary
- implement DBSCAN clustering service with persistence
- wire clustering into memory service and initialize in app startup
- enable Dream Job Orchestrator for salience decay and reclustering

## Testing
- `ruff check src/memory_palace/services`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a1c816490832188729df32ddd8182